### PR TITLE
Potential fix for code scanning alert no. 35: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -5,6 +5,9 @@ on:
     branches: ["**"]
   pull_request:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/blycr/msp/security/code-scanning/35](https://github.com/blycr/msp/security/code-scanning/35)

Add an explicit workflow-level `permissions` block so all jobs inherit minimal token rights unless overridden.  
Best fix here (without changing behavior): add at the top level of `.github/workflows/check.yml`, near `on:`/`concurrency:`

```yaml
permissions:
  contents: read
```

This is the minimal recommended baseline and should satisfy checkout/read-only CI tasks while documenting intended privilege.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
